### PR TITLE
Issue 65: Pause connector consumer when processing batch of records

### DIFF
--- a/src/main/java/io/coffeebeans/connect/azure/blob/sink/AzureBlobSinkConnectorContext.java
+++ b/src/main/java/io/coffeebeans/connect/azure/blob/sink/AzureBlobSinkConnectorContext.java
@@ -14,6 +14,7 @@ import io.coffeebeans.connect.azure.blob.sink.storage.StorageManager;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -231,6 +232,24 @@ public class AzureBlobSinkConnectorContext {
      */
     public static AzureBlobSinkConnectorContext.Builder builder(Map<String, String> configProps) {
         return new Builder(configProps);
+    }
+
+    /**
+     * Pauses the kafka-connect consumer for the given topic-partition.
+     *
+     * @param topicPartition TopicPartition for which consumer should stop consuming
+     */
+    public void pause(TopicPartition topicPartition) {
+        this.sinkTaskContext.pause(topicPartition);
+    }
+
+    /**
+     * Resumes the kafka-connect consumer for the given topic-partition.
+     *
+     * @param topicPartition TopicPartition for which consumer should start consuming
+     */
+    public void resume(TopicPartition topicPartition) {
+        this.sinkTaskContext.resume(topicPartition);
     }
 
     /**

--- a/src/main/java/io/coffeebeans/connect/azure/blob/sink/AzureBlobSinkTask.java
+++ b/src/main/java/io/coffeebeans/connect/azure/blob/sink/AzureBlobSinkTask.java
@@ -124,7 +124,7 @@ public class AzureBlobSinkTask extends SinkTask {
             TopicPartitionWriter topicPartitionWriter = topicPartitionWriters.get(topicPartition);
 
             if (topicPartitionWriter == null) {
-                topicPartitionWriter = newTopicPartitionWriter();
+                topicPartitionWriter = newTopicPartitionWriter(topicPartition);
                 topicPartitionWriters.put(topicPartition, topicPartitionWriter);
             }
             topicPartitionWriter.buffer(record);
@@ -171,7 +171,7 @@ public class AzureBlobSinkTask extends SinkTask {
     @Override
     public void open(Collection<TopicPartition> topicPartitions) {
         for (TopicPartition topicPartition : topicPartitions) {
-            topicPartitionWriters.put(topicPartition, newTopicPartitionWriter());
+            topicPartitionWriters.put(topicPartition, newTopicPartitionWriter(topicPartition));
         }
     }
 
@@ -215,9 +215,9 @@ public class AzureBlobSinkTask extends SinkTask {
      *
      * @return new instance of TopicPartitionWriter
      */
-    private TopicPartitionWriter newTopicPartitionWriter() {
+    private TopicPartitionWriter newTopicPartitionWriter(TopicPartition topicPartition) {
 
-        return new TopicPartitionWriter(this.azureBlobSinkConnectorContext);
+        return new TopicPartitionWriter(topicPartition, this.azureBlobSinkConnectorContext);
     }
 
     /**

--- a/src/test/java/io/coffeebeans/connect/azure/blob/sink/TopicPartitionWriterTest.java
+++ b/src/test/java/io/coffeebeans/connect/azure/blob/sink/TopicPartitionWriterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.coffeebeans.connect.azure.blob.sink.config.AzureBlobSinkConfig;
 import io.coffeebeans.connect.azure.blob.sink.format.RecordWriter;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,8 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TopicPartitionWriterTest {
+    private static final String TOPIC = "TEST_TOPIC";
+    private static final int PARTITION = 1;
 
     @Mock
     private RecordWriter recordWriter;
@@ -74,7 +77,7 @@ public class TopicPartitionWriterTest {
                 .when(context)
                 .sendToDeadLetterQueue(any(), any());
 
-        topicPartitionWriter = new TopicPartitionWriter(context);
+        topicPartitionWriter = new TopicPartitionWriter(new TopicPartition(TOPIC, PARTITION), context);
 
         when(config.getFlushSize())
                 .thenReturn(1);
@@ -173,7 +176,8 @@ public class TopicPartitionWriterTest {
                 .thenReturn(-1L);
 
         // instantiate topic partition writer
-        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(context);
+        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(
+                new TopicPartition(TOPIC, PARTITION), context);
 
         localTopicPartitionWriter.buffer(firstSinkRecord);
         localTopicPartitionWriter.buffer(secondSinkRecord);
@@ -230,7 +234,8 @@ public class TopicPartitionWriterTest {
                 .thenReturn(1L);
 
         // instantiate topic partition writer
-        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(context);
+        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(
+                new TopicPartition(TOPIC, PARTITION), context);
 
         // Buffering and writing first record
         localTopicPartitionWriter.buffer(firstSinkRecord);
@@ -309,7 +314,8 @@ public class TopicPartitionWriterTest {
                 .thenReturn(1L);
 
         // instantiate topic partition writer
-        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(context);
+        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(
+                new TopicPartition(TOPIC, PARTITION), context);
 
         // Buffering and writing first record
         localTopicPartitionWriter.buffer(firstSinkRecord);
@@ -395,7 +401,8 @@ public class TopicPartitionWriterTest {
                 .thenReturn(-1L);
 
         // instantiate topic partition writer
-        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(context);
+        TopicPartitionWriter localTopicPartitionWriter = new TopicPartitionWriter(
+                new TopicPartition(TOPIC, PARTITION), context);
 
         // Buffering the record
         localTopicPartitionWriter.buffer(firstSinkRecord);


### PR DESCRIPTION
## Problem
Memory out of exception when consuming from Kafka topic which has huge data stored or high traffic.

## Solution
Pause the connector consumer while processing the batch of messages and resume once done.  

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests
